### PR TITLE
add checkbox newline parsing

### DIFF
--- a/src/CodeInput.tsx
+++ b/src/CodeInput.tsx
@@ -49,6 +49,31 @@ const EditorContainer = styled(Card)`
   }
 `
 
+const CheckboxContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 4px;
+`
+
+const CheckboxLabel = styled.label`
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: ${({theme}) => theme.sanity.color.muted.default};
+`
+
+const CheckboxInput = styled.input`
+  margin: 0;
+  padding: 0;
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid ${({theme}) => theme.sanity.color.base.focusRing};
+  border-radius: ${({theme}) => theme.sanity.radius[1]};
+  background-color: ${({theme}) => theme.sanity.color.base.bg};
+  box-shadow: inset 0 0 0 1px ${({theme}) => theme.sanity.color.border};
+  transition: all 150ms;
+`
+
 export interface CodeInputProps {
   compareValue?: CodeInputValue
   focusPath: Path
@@ -83,7 +108,6 @@ const CodeInput = React.forwardRef(
     const aceEditorRef = useRef<any>()
     const aceEditorId = useId()
     const [isCboxChecked, setIsCboxChecked] = React.useState(false)
-
     const {
       onFocus,
       onChange,
@@ -185,31 +209,9 @@ const CodeInput = React.forwardRef(
     }, [aceEditorRef, handleGutterMouseDown])
 
     useEffect(() => {
-      const cBox = document.createElement('input')
-      cBox.setAttribute('type', 'checkbox')
-      cBox.setAttribute('id', 'toggle-remove-lines')
-      cBox.addEventListener('change', function () {
-        // save the state of the checkbox
-        setIsCboxChecked(cBox.checked)
-        localStorage.setItem('codeInput-isCboxChecked', cBox.checked.toString())
-      })
-      cBox.checked = localStorage.getItem('codeInput-isCboxChecked') === 'true'
-      setIsCboxChecked(cBox.checked)
-      const label = document.createElement('label')
-      label.setAttribute('for', 'toggle-remove-lines')
-      label.innerHTML = 'I am pasting code from Word'
-      const cBoxContainer = document.createElement('div')
-      cBoxContainer.style.display = 'flex'
-      cBoxContainer.style.alignItems = 'center'
-      cBoxContainer.style.gap = '0.5rem'
-      cBoxContainer.appendChild(cBox)
-      cBoxContainer.appendChild(label)
-      const editor = aceEditorRef.current.editor
-      // container has a lot of parents, so we need to go up a few levels
-      const editorEl = editor.container.parentNode.parentNode.parentNode.parentNode.parentNode
-      // add checkbox and label before the editor
-      editorEl.insertAdjacentElement('beforebegin', cBoxContainer)
-    }, [aceEditorRef])
+      const isChecked = localStorage.getItem('codeInput-isCboxChecked') === 'true'
+      setIsCboxChecked(isChecked)
+    }, [setIsCboxChecked])
 
     const handleEditorLoad = useCallback(
       (editor: any) => {
@@ -414,7 +416,6 @@ const CodeInput = React.forwardRef(
       onBlur,
       value?.filename,
     ])
-
     const renderEditor = useCallback(() => {
       const fixedLanguage = type.options?.language
 
@@ -436,6 +437,20 @@ const CodeInput = React.forwardRef(
           compareValue={codeCompareValue}
         >
           <FormField label="Code" level={level + 1} __unstable_presence={codePresence}>
+            <CheckboxContainer>
+              <CheckboxInput
+                type="checkbox"
+                id="toggle-remove-lines"
+                checked={isCboxChecked}
+                onChange={(e) => {
+                  setIsCboxChecked(e.target.checked)
+                  localStorage.setItem('codeInput-isCboxChecked', e.target.checked.toString())
+                }}
+              />
+              <CheckboxLabel htmlFor="toggle-remove-lines">
+                I am pasting code from Word
+              </CheckboxLabel>
+            </CheckboxContainer>
             <EditorContainer radius={1} shadow={1} readOnly={readOnly}>
               <AceEditor
                 ref={aceEditorRef}

--- a/src/CodeInput.tsx
+++ b/src/CodeInput.tsx
@@ -107,7 +107,9 @@ const CodeInput = React.forwardRef(
   (props: CodeInputProps, ref: React.ForwardedRef<{focus: () => void}>) => {
     const aceEditorRef = useRef<any>()
     const aceEditorId = useId()
-    const [isCboxChecked, setIsCboxChecked] = React.useState(false)
+    const [isCboxChecked, setIsCboxChecked] = React.useState(() => {
+      return localStorage.getItem('codeInput-isCboxChecked') === 'true'
+    })
     const {
       onFocus,
       onChange,
@@ -207,11 +209,6 @@ const CodeInput = React.forwardRef(
         editor?.session?.removeListener('guttermousedown', handleGutterMouseDown)
       }
     }, [aceEditorRef, handleGutterMouseDown])
-
-    useEffect(() => {
-      const isChecked = localStorage.getItem('codeInput-isCboxChecked') === 'true'
-      setIsCboxChecked(isChecked)
-    }, [setIsCboxChecked])
 
     const handleEditorLoad = useCallback(
       (editor: any) => {

--- a/src/CodeInput.tsx
+++ b/src/CodeInput.tsx
@@ -83,6 +83,7 @@ const CodeInput = React.forwardRef(
     const aceEditorRef = useRef<any>()
     const aceEditorId = useId()
     const [isCboxChecked, setIsCboxChecked] = React.useState(false)
+
     const {
       onFocus,
       onChange,
@@ -190,7 +191,10 @@ const CodeInput = React.forwardRef(
       cBox.addEventListener('change', function () {
         // save the state of the checkbox
         setIsCboxChecked(cBox.checked)
+        localStorage.setItem('codeInput-isCboxChecked', cBox.checked.toString())
       })
+      cBox.checked = localStorage.getItem('codeInput-isCboxChecked') === 'true'
+      setIsCboxChecked(cBox.checked)
       const label = document.createElement('label')
       label.setAttribute('for', 'toggle-remove-lines')
       label.innerHTML = 'I am pasting code from Word'
@@ -293,7 +297,7 @@ const CodeInput = React.forwardRef(
           ])
         )
       },
-      [onChange, type]
+      [onChange, type, isCboxChecked]
     )
 
     const handleLanguageChange = useCallback(


### PR DESCRIPTION
add checkbox to code editor for toggling pasting from word.
use localstorage to save value.
run new line parsing script when code is pasted in

to test: clone repo and run `npm install` then run `yarn link`

in our website repo: cd into sanity folder and run `yarn link @sanity/code-input`

code editor should have the checkbox, checkbox value should persist when reopening and pasted code should have extra newlines removed when its checked.